### PR TITLE
Bump version to 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "card-validator",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A library for validating credit card fields",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Version was set to 2.0.0, then reverted to 1.0.0. Since there was new functionality introduced by [credit-card-type@2.0.0](https://github.com/braintree/credit-card-type/releases/tag/2.0.0), a version bump of some sort is warranted.