### PR TITLE
Update credit-card-type to version 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+unreleased
+==========
+
+- Update `credit-card-type` to 3.0.0
+
 2.0.1
 =====
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 unreleased
 ==========
 
-- Update `credit-card-type` to 3.0.0
+- Update `credit-card-type` to 4.0.0
 
 2.0.1
 =====

--- a/package.json
+++ b/package.json
@@ -38,9 +38,9 @@
     "vinyl-source-stream": "^1.0.0"
   },
   "dependencies": {
-    "lodash.isnumber": "^3.0.1",
-    "credit-card-type": "^3.0.0",
+    "credit-card-type": "^4.0.0",
     "lodash.assign": "^3.0.0",
+    "lodash.isnumber": "^3.0.1",
     "lodash.isstring": "^3.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "lodash.isnumber": "^3.0.1",
-    "credit-card-type": "^2.0.0",
+    "credit-card-type": "^3.0.0",
     "lodash.assign": "^3.0.0",
     "lodash.isstring": "^3.0.1"
   }

--- a/src/card-number.js
+++ b/src/card-number.js
@@ -34,7 +34,7 @@ function cardNumber(value) {
   if (!/^\d*$/.test(value)) { return verification(null, false, false); }
 
   cardType = getCardType(value);
-  if (isEmptyObject(cardType)) { return verification(null, false, false); }
+  if (isEmptyObject(cardType)) { return verification(null, true, false); }
 
   if (cardType.type === 'unionpay') { // UnionPay is not Luhn 10 compliant
     valid = true;

--- a/src/card-number.js
+++ b/src/card-number.js
@@ -1,25 +1,15 @@
 var isString = require('lodash.isstring');
 var extend = require('lodash.assign');
 var luhn10 = require('./luhn-10');
-var getCardType = require('credit-card-type');
+var getCardTypes = require('credit-card-type');
 var isNumber = require('lodash.isnumber');
 
 function verification(card, isPotentiallyValid, isValid) {
   return extend({}, {card: card, isPotentiallyValid: isPotentiallyValid, isValid: isValid});
 }
 
-function isEmptyObject(object) {
-  var key;
-
-  for (key in object) {
-    if (object.hasOwnProperty(key)) { return false; }
-  }
-
-  return true;
-}
-
 function cardNumber(value) {
-  var cardType, valid, i, maxLength;
+  var potentialTypes, cardType, valid, i, maxLength;
 
   if (isNumber(value)) {
     value = String(value);
@@ -27,16 +17,21 @@ function cardNumber(value) {
 
   if (!isString(value)) { return verification(null, false, false); }
 
-  if (value === '') { return verification(null, true, false); }
-
   value = value.replace(/\-|\s/g, '');
 
   if (!/^\d*$/.test(value)) { return verification(null, false, false); }
 
-  cardType = getCardType(value);
-  if (isEmptyObject(cardType)) { return verification(null, true, false); }
+  potentialTypes = getCardTypes(value);
 
-  if (cardType.type === 'unionpay') { // UnionPay is not Luhn 10 compliant
+  if (potentialTypes.length === 0) {
+    return verification(null, false, false);
+  } else if (potentialTypes.length !== 1) {
+    return verification(null, true, false);
+  }
+
+  cardType = potentialTypes[0];
+
+  if (cardType.type === 'unionpay') {  // UnionPay is not Luhn 10 compliant
     valid = true;
   } else {
     valid = luhn10(value);

--- a/test/unit/card-number.js
+++ b/test/unit/card-number.js
@@ -8,11 +8,11 @@ describe('number validates', function () {
       ['',
         {card: null, isPotentiallyValid: true, isValid: false}],
       ['6',
-        {card: 'maestro', isPotentiallyValid: true, isValid: false}],
-      ['60',
-        {card: 'maestro', isPotentiallyValid: true, isValid: false}],
+        {card: null, isPotentiallyValid: true, isValid: false}],
+        ['60',
+        {card: null, isPotentiallyValid: true, isValid: false}],
       ['601',
-        {card: 'maestro', isPotentiallyValid: true, isValid: false}],
+        {card: null, isPotentiallyValid: true, isValid: false}],
       ['6011',
         {card: 'discover', isPotentiallyValid: true, isValid: false}],
       ['4',
@@ -24,14 +24,16 @@ describe('number validates', function () {
       ['',
         {card: null, isPotentiallyValid: true, isValid: false}],
       ['x',
-        {card: null, isPotentiallyValid: false, isValid: false}]
+        {card: null, isPotentiallyValid: false, isValid: false}],
+      ['1',
+        {card: null, isPotentiallyValid: true, isValid: false}],
+      ['123',
+        {card: null, isPotentiallyValid: true, isValid: false}],
     ]);
   });
 
   describe('normal cases', function () {
     table([
-      ['123',
-        {card: null, isPotentiallyValid: false, isValid: false}],
       ['4012888888881881',
         {card: 'visa', isPotentiallyValid: true, isValid: true}],
       ['6288997715452584',
@@ -112,8 +114,6 @@ describe('number validates', function () {
     table([
       ['',
         {card: null, isPotentiallyValid: true, isValid: false}],
-      ['1',
-        {card: null, isPotentiallyValid: false, isValid: false}],
       ['foo',
         {card: null, isPotentiallyValid: false, isValid: false}],
       [{},
@@ -121,7 +121,7 @@ describe('number validates', function () {
       [[],
         {card: null, isPotentiallyValid: false, isValid: false}],
       [32908234,
-        {card: null, isPotentiallyValid: false, isValid: false}],
+        {card: null, isPotentiallyValid: true, isValid: false}],
       [4111111111111111,
         {card: 'visa', isPotentiallyValid: true, isValid: true}],
       [true,

--- a/test/unit/card-number.js
+++ b/test/unit/card-number.js
@@ -9,10 +9,8 @@ describe('number validates', function () {
         {card: null, isPotentiallyValid: true, isValid: false}],
       ['6',
         {card: null, isPotentiallyValid: true, isValid: false}],
-        ['60',
-        {card: null, isPotentiallyValid: true, isValid: false}],
       ['601',
-        {card: null, isPotentiallyValid: true, isValid: false}],
+        {card: 'discover', isPotentiallyValid: true, isValid: false}],
       ['6011',
         {card: 'discover', isPotentiallyValid: true, isValid: false}],
       ['4',
@@ -25,10 +23,8 @@ describe('number validates', function () {
         {card: null, isPotentiallyValid: true, isValid: false}],
       ['x',
         {card: null, isPotentiallyValid: false, isValid: false}],
-      ['1',
-        {card: null, isPotentiallyValid: true, isValid: false}],
       ['123',
-        {card: null, isPotentiallyValid: true, isValid: false}],
+        {card: null, isPotentiallyValid: false, isValid: false}],
     ]);
   });
 
@@ -74,6 +70,8 @@ describe('number validates', function () {
 
   describe('Discover', function () {
     table([
+      ['60',
+        {card: 'discover', isPotentiallyValid: true, isValid: false}],
       ['6011111',
         {card: 'discover', isPotentiallyValid: true, isValid: false}],
       ['6011111111111117',
@@ -103,6 +101,10 @@ describe('number validates', function () {
 
   describe('JCB', function () {
     table([
+      ['1',
+        {card: 'jcb', isPotentiallyValid: true, isValid: false}],
+      ['2',
+        {card: 'jcb', isPotentiallyValid: true, isValid: false}],
       ['3530111',
         {card: 'jcb', isPotentiallyValid: true, isValid: false}],
       ['3530111333300000',
@@ -120,8 +122,10 @@ describe('number validates', function () {
         {card: null, isPotentiallyValid: false, isValid: false}],
       [[],
         {card: null, isPotentiallyValid: false, isValid: false}],
+      ['32908234',
+        {card: null, isPotentiallyValid: false, isValid: false}],
       [32908234,
-        {card: null, isPotentiallyValid: true, isValid: false}],
+        {card: null, isPotentiallyValid: false, isValid: false}],
       [4111111111111111,
         {card: 'visa', isPotentiallyValid: true, isValid: true}],
       [true,


### PR DESCRIPTION
This updates the [credit-card-type module](https://github.com/braintree/credit-card-type/) to 4.0.0 and fixes tests to reflect its changes.

This also fixes #10.