### PR TITLE
CVV validation accepts an array of possible lengths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+UNRELEASED
+==========
+
+- CVV validator can accept an array of possible length values
+
 2.1.0
 =====
 

--- a/src/cvv.js
+++ b/src/cvv.js
@@ -1,18 +1,51 @@
 var isString = require('lodash.isstring');
 var DEFAULT_LENGTH = 3;
 
+function includes(array, thing) {
+  var i = 0;
+
+  for (; i < array.length; i++) {
+    if (thing === array[i]) { return true; }
+  }
+
+  return false;
+}
+
+function min(array) {
+  var minimum = DEFAULT_LENGTH;
+  var i = 0;
+
+  for (; i < array.length; i++) {
+    minimum = array[i] < minimum ? array[i] : minimum;
+  }
+
+  return minimum;
+}
+
+function max(array) {
+  var maximum = DEFAULT_LENGTH;
+  var i = 0;
+
+  for (; i < array.length; i++) {
+    maximum = array[i] > maximum ? array[i] : maximum;
+  }
+
+  return maximum;
+}
+
 function verification(isValid, isPotentiallyValid) {
   return {isValid: isValid, isPotentiallyValid: isPotentiallyValid};
 }
 
 function cvv(value, maxLength) {
   maxLength = maxLength || DEFAULT_LENGTH;
+  maxLength = maxLength instanceof Array ? maxLength : [maxLength];
 
   if (!isString(value)) { return verification(false, false); }
   if (!/^\d*$/.test(value)) { return verification(false, false); }
-  if (value.length === maxLength) { return verification(true, true); }
-  if (value.length < maxLength) { return verification(false, true); }
-  if (value.length > maxLength) { return verification(false, false); }
+  if (includes(maxLength, value.length)) { return verification(true, true); }
+  if (value.length < min(maxLength)) { return verification(false, true); }
+  if (value.length > max(maxLength)) { return verification(false, false); }
 
   return verification(true, true);
 }

--- a/test/unit/cvv.js
+++ b/test/unit/cvv.js
@@ -7,6 +7,7 @@ describe('cvv', function () {
       'potentiallyValid': [
         ['', {isValid: false, isPotentiallyValid: true}],
         ['1', {isValid: false, isPotentiallyValid: true}],
+        ['1', {isValid: false, isPotentiallyValid: true}, [3,4]],
         ['12', {isValid: false, isPotentiallyValid: true}]
       ],
 
@@ -14,12 +15,15 @@ describe('cvv', function () {
         ['000', {isValid: true, isPotentiallyValid: true}],
         ['0000', {isValid: true, isPotentiallyValid: true}, 4],
         ['123', {isValid: true, isPotentiallyValid: true}],
-        ['1234', {isValid: true, isPotentiallyValid: true}, 4]
+        ['1234', {isValid: true, isPotentiallyValid: true}, 4],
+        ['1234', {isValid: true, isPotentiallyValid: true}, [3,4]],
+        ['123', {isValid: true, isPotentiallyValid: true}, [3,4]]
       ],
 
       'returns false for invalid strings': [
         ['12345', {isValid: false, isPotentiallyValid: false}],
-          ['foo', {isValid: false, isPotentiallyValid: false}],
+        ['12345', {isValid: false, isPotentiallyValid: false}, [3,4]],
+        ['foo', {isValid: false, isPotentiallyValid: false}],
         ['-123', {isValid: false, isPotentiallyValid: false}],
         ['12 34', {isValid: false, isPotentiallyValid: false}],
         ['12/34', {isValid: false, isPotentiallyValid: false}],


### PR DESCRIPTION
This is for scenarios where we don't know the card number beforehand but want to accept a CVV/CID/etc value.

A use case would be requesting a customer to supply CVV validation before using a previously stored credit card.

```javascript
valid.cvv('123', [3,4]); // could be amex or visa
// -> isValid: true, isPotentiallyValid: true
```