### PR TITLE
Fix CVV validation to not always validate 3-digit values as true

### DIFF
--- a/src/cvv.js
+++ b/src/cvv.js
@@ -11,17 +11,6 @@ function includes(array, thing) {
   return false;
 }
 
-function min(array) {
-  var minimum = DEFAULT_LENGTH;
-  var i = 0;
-
-  for (; i < array.length; i++) {
-    minimum = array[i] < minimum ? array[i] : minimum;
-  }
-
-  return minimum;
-}
-
 function max(array) {
   var maximum = DEFAULT_LENGTH;
   var i = 0;
@@ -44,7 +33,7 @@ function cvv(value, maxLength) {
   if (!isString(value)) { return verification(false, false); }
   if (!/^\d*$/.test(value)) { return verification(false, false); }
   if (includes(maxLength, value.length)) { return verification(true, true); }
-  if (value.length < min(maxLength)) { return verification(false, true); }
+  if (value.length < Math.min.apply(null, maxLength)) { return verification(false, true); }
   if (value.length > max(maxLength)) { return verification(false, false); }
 
   return verification(true, true);

--- a/test/unit/cvv.js
+++ b/test/unit/cvv.js
@@ -8,7 +8,9 @@ describe('cvv', function () {
         ['', {isValid: false, isPotentiallyValid: true}],
         ['1', {isValid: false, isPotentiallyValid: true}],
         ['1', {isValid: false, isPotentiallyValid: true}, [3,4]],
-        ['12', {isValid: false, isPotentiallyValid: true}]
+        ['1', {isValid: false, isPotentiallyValid: true}, [4,3]],
+        ['12', {isValid: false, isPotentiallyValid: true}],
+        ['123', {isValid: false, isPotentiallyValid: true}, 4]
       ],
 
       'returns true for valid strings': [
@@ -23,6 +25,8 @@ describe('cvv', function () {
       'returns false for invalid strings': [
         ['12345', {isValid: false, isPotentiallyValid: false}],
         ['12345', {isValid: false, isPotentiallyValid: false}, [3,4]],
+        ['1234', {isValid: false, isPotentiallyValid: false}],
+        ['1234', {isValid: false, isPotentiallyValid: false}, 3],
         ['foo', {isValid: false, isPotentiallyValid: false}],
         ['-123', {isValid: false, isPotentiallyValid: false}],
         ['12 34', {isValid: false, isPotentiallyValid: false}],
@@ -32,7 +36,7 @@ describe('cvv', function () {
 
       'returns false for non-string types': [
         [0, {isValid: false, isPotentiallyValid: false}],
-          [123, {isValid: false, isPotentiallyValid: false}],
+        [123, {isValid: false, isPotentiallyValid: false}],
         [1234, {isValid: false, isPotentiallyValid: false}],
         [-1234, {isValid: false, isPotentiallyValid: false}],
         [-10, {isValid: false, isPotentiallyValid: false}],


### PR DESCRIPTION
In our CVV validation, we had a default minimum maxLength of 3. This meant for cards with 4-digit CVV/CID, 3-digit values were considered valid. 

The minimum maxLength will still default to 3 when no lengths are specified.
> ['123', {isValid: false, isPotentiallyValid: true}] // minimum maxLength = 3

When lengths are specified, the minimum maxLength will be the shortest value provided.
> ['123', {isValid: false, isPotentiallyValid: true}, [4,5] ] // minimum maxLength = 4