### PR TITLE
Expiration date validation fixes

### DIFF
--- a/src/parse-date.js
+++ b/src/parse-date.js
@@ -22,7 +22,7 @@ function parseDate(value) {
   if (value[0] === '1') {
     year = value.substr(1);
     yearValid = expirationYear(year);
-    if (!yearValid.isValid) {
+    if (!yearValid.isPotentiallyValid) {
       len = 2;
     }
   }

--- a/src/parse-date.js
+++ b/src/parse-date.js
@@ -1,11 +1,16 @@
 var expirationYear = require('./expiration-year');
+var isArray = require('lodash/lang/isArray');
 
 function parseDate(value) {
   var month, len, year, yearValid;
 
   if (value.match('/')) {
     value = value.split(/\s*\/\s*/g);
+  } else if (value.match(' ')) {
+    value = value.split(/ +/g);
+  }
 
+  if (isArray(value)) {
     return {
       month: value[0],
       year: value.slice(1).join()

--- a/src/parse-date.js
+++ b/src/parse-date.js
@@ -17,10 +17,10 @@ function parseDate(value) {
     };
   }
 
-  len = value[0] === '0' || value.length > 5 || value.length === 4 ? 2 : 1;
+  len = value[0] === '0' || value.length > 5 ? 2 : 1;
 
-  if (value.length === 3 && value[0] === '1') {
-    year = value.substr(1, 2);
+  if (value[0] === '1') {
+    year = value.substr(1);
     yearValid = expirationYear(year);
     if (!yearValid.isValid) {
       len = 2;

--- a/src/parse-date.js
+++ b/src/parse-date.js
@@ -31,7 +31,7 @@ function parseDate(value) {
 
   return {
     month: month,
-    year: value.substr(month.length, 4)
+    year: value.substr(month.length)
   };
 }
 

--- a/src/parse-date.js
+++ b/src/parse-date.js
@@ -4,9 +4,9 @@ var isArray = require('lodash/lang/isArray');
 function parseDate(value) {
   var month, len, year, yearValid;
 
-  if (value.match('/')) {
+  if (/\//.test(value)) {
     value = value.split(/\s*\/\s*/g);
-  } else if (value.match(' ')) {
+  } else if (/\s/.test(value)) {
     value = value.split(/ +/g);
   }
 

--- a/test/unit/expiration-date.js
+++ b/test/unit/expiration-date.js
@@ -142,6 +142,7 @@ describe('expirationDate validates', function () {
     'ambiguous expiration dates with no slashes': [
       ['011', {isValid: false, isPotentiallyValid: true, month: null, year: null}],
       ['111', {isValid: false, isPotentiallyValid: true, month: null, year: null}],
+      ['2202', {isValid: false, isPotentiallyValid: true, month: null, year: null}],
       ['01201', {isValid: false, isPotentiallyValid: true, month: null, year: null}],
       ['01211', {isValid: false, isPotentiallyValid: false, month: null, year: null}],
       ['01199', {isValid: false, isPotentiallyValid: false, month: null, year: null}],

--- a/test/unit/expiration-date.js
+++ b/test/unit/expiration-date.js
@@ -143,6 +143,7 @@ describe('expirationDate validates', function () {
       ['011', {isValid: false, isPotentiallyValid: true, month: null, year: null}],
       ['111', {isValid: false, isPotentiallyValid: true, month: null, year: null}],
       ['2202', {isValid: false, isPotentiallyValid: true, month: null, year: null}],
+      ['1202', {isValid: false, isPotentiallyValid: true, month: null, year: null}],
       ['01201', {isValid: false, isPotentiallyValid: true, month: null, year: null}],
       ['01211', {isValid: false, isPotentiallyValid: false, month: null, year: null}],
       ['01199', {isValid: false, isPotentiallyValid: false, month: null, year: null}],

--- a/test/unit/expiration-date.js
+++ b/test/unit/expiration-date.js
@@ -101,7 +101,31 @@ describe('expirationDate validates', function () {
       ['01 ' + (currentYear + 4), {isValid: true, isPotentiallyValid: true, month: '01', year: (currentYear + 4).toString()}],
       ['01 ' + (currentYear + 5), {isValid: true, isPotentiallyValid: true, month: '01', year: (currentYear + 5).toString()}],
       ['01 ' + (twoDigitYear + 4), {isValid: true, isPotentiallyValid: true, month: '01', year: (twoDigitYear + 4).toString()}],
-      ['01 ' + (twoDigitYear + 6), {isValid: true, isPotentiallyValid: true, month: '01', year: (twoDigitYear + 6).toString()}]
+      ['01 ' + (twoDigitYear + 6), {isValid: true, isPotentiallyValid: true, month: '01', year: (twoDigitYear + 6).toString()}],
+      ['1 ' + (currentYear + 4), {isValid: true, isPotentiallyValid: true, month: '1', year: (currentYear + 4).toString()}],
+      ['1 ' + (currentYear + 5), {isValid: true, isPotentiallyValid: true, month: '1', year: (currentYear + 5).toString()}],
+      ['1 ' + (twoDigitYear + 4), {isValid: true, isPotentiallyValid: true, month: '1', year: (twoDigitYear + 4).toString()}],
+      ['1 ' + (twoDigitYear + 5), {isValid: true, isPotentiallyValid: true, month: '1', year: (twoDigitYear + 5).toString()}],
+      ['9 ' + (currentYear + 4), {isValid: true, isPotentiallyValid: true, month: '9', year: (currentYear + 4).toString()}],
+      ['9 ' + (currentYear + 5), {isValid: true, isPotentiallyValid: true, month: '9', year: (currentYear + 5).toString()}]
+    ],
+
+    'ambiguous space separated month and year': [
+      ['1 2', {isValid: false, isPotentiallyValid: true, month: null, year: null}],
+      ['1 202', {isValid: false, isPotentiallyValid: true, month: null, year: null}],
+      ['1 ', {isValid: false, isPotentiallyValid: true, month: null, year: null}],
+      ['12 2', {isValid: false, isPotentiallyValid: true, month: null, year: null}],
+      ['12 202', {isValid: false, isPotentiallyValid: true, month: null, year: null}],
+      ['12 ', {isValid: false, isPotentiallyValid: true, month: null, year: null}]
+    ],
+
+    'invalid space separated month and year': [
+      ['11 11', {isValid: false, isPotentiallyValid: false, month: null, year: null}],
+      ['00 ' + nextYear, {isValid: false, isPotentiallyValid: false, month: null, year: null}],
+      ['13 ' + nextYear, {isValid: false, isPotentiallyValid: false, month: null, year: null}],
+      ['01 1999', {isValid: false, isPotentiallyValid: false, month: null, year: null}],
+      ['01 1999', {isValid: false, isPotentiallyValid: false, month: null, year: null}],
+      ['01 2100', {isValid: false, isPotentiallyValid: false, month: null, year: null}]
     ],
 
     'invalid expiration dates with no slashes': [
@@ -149,8 +173,6 @@ describe('expirationDate validates', function () {
     'malformed strings': [
       ['foo', {isValid: false, isPotentiallyValid: false, month: null, year: null}],
       ['1.2', {isValid: false, isPotentiallyValid: false, month: null, year: null}],
-      ['1 2', {isValid: false, isPotentiallyValid: false, month: null, year: null}],
-      ['1 ', {isValid: false, isPotentiallyValid: true, month: null, year: null}],
       [' 1', {isValid: false, isPotentiallyValid: true, month: null, year: null}],
       ['01 / 20015', {isValid: false, isPotentiallyValid: false, month: null, year: null}],
       ['15  / 2016', {isValid: false, isPotentiallyValid: false, month: null, year: null}],

--- a/test/unit/expiration-date.js
+++ b/test/unit/expiration-date.js
@@ -93,8 +93,8 @@ describe('expirationDate validates', function () {
       ['9' + nextYear, {isValid: true, isPotentiallyValid: true, month: '9', year: nextYear.toString()}],
       ['1' + (twoDigitYear + 1), {isValid: true, isPotentiallyValid: true, month: '1',  year: (twoDigitYear + 1).toString()}],
       ['9' + (twoDigitYear + 1), {isValid: true, isPotentiallyValid: true, month: '9',  year: (twoDigitYear + 1).toString()}],
-      ['1219', {isValid: true, isPotentiallyValid: true, month: '12', year: '19'}],
-      ['0116', {isValid: true, isPotentiallyValid: true, month: '01', year: '16'}]
+      ['12' + (twoDigitYear + 1), {isValid: true, isPotentiallyValid: true, month: '12', year: (twoDigitYear + 1).toString()}],
+      ['01' + (twoDigitYear + 1), {isValid: true, isPotentiallyValid: true, month: '01', year: (twoDigitYear + 1).toString()}]
     ],
 
     'valid space separated month and year': [
@@ -132,8 +132,8 @@ describe('expirationDate validates', function () {
       [' ', {isValid: false, isPotentiallyValid: true, month: null, year: null}],
       ['  ', {isValid: false, isPotentiallyValid: true, month: null, year: null}],
       ['1111', {isValid: false, isPotentiallyValid: false, month: null, year: null}],
-      ['002016', {isValid: false, isPotentiallyValid: false, month: null, year: null}],
-      ['132016', {isValid: false, isPotentiallyValid: false, month: null, year: null}],
+      ['00' + nextYear, {isValid: false, isPotentiallyValid: false, month: null, year: null}],
+      ['13' + nextYear, {isValid: false, isPotentiallyValid: false, month: null, year: null}],
       ['011999', {isValid: false, isPotentiallyValid: false, month: null, year: null}],
       ['011999', {isValid: false, isPotentiallyValid: false, month: null, year: null}],
       ['012100', {isValid: false, isPotentiallyValid: false, month: null, year: null}]

--- a/test/unit/expiration-date.js
+++ b/test/unit/expiration-date.js
@@ -173,6 +173,7 @@ describe('expirationDate validates', function () {
 
     'malformed strings': [
       ['foo', {isValid: false, isPotentiallyValid: false, month: null, year: null}],
+      ['0120197', {isValid: false, isPotentiallyValid: false, month: null, year: null}],
       ['1.2', {isValid: false, isPotentiallyValid: false, month: null, year: null}],
       [' 1', {isValid: false, isPotentiallyValid: true, month: null, year: null}],
       ['01 / 20015', {isValid: false, isPotentiallyValid: false, month: null, year: null}],


### PR DESCRIPTION
This PR fixes a few bugs in expiration date validation.

1. Validation of space separated expiration dates. Currently expiration dates separated by spaces require six digits, so dates like `1 2020` are considered invalid. By treating spaces like slashes, we now validate them correctly. 
1. Potential validity of slashless expiration dates. Currently the flow of typing in the date `12020` looks like this:
![expiration-before](https://cloud.githubusercontent.com/assets/7514489/11967368/e41cca0a-a8c7-11e5-89a2-a1e4bf3d24b2.gif)
Now it looks like this:
![expiration-also](https://cloud.githubusercontent.com/assets/7514489/11967376/ef4bdccc-a8c7-11e5-8fab-62a1d3a7769d.gif)

1. Validation of dates that are too long. Currently inputs like `0120197` are considered valid due to cutting the string down to six digits before validating it. We now validate the entire too-long string, which is invalid. 

This PR also adds some test coverage across the board.