### PR TITLE
Use a non-golfed version of the Luhn Algorithm

### DIFF
--- a/src/luhn-10.js
+++ b/src/luhn-10.js
@@ -1,8 +1,51 @@
+/*
+ * Luhn algorithm implementation in JavaScript
+ * Copyright (c) 2009 Nicholas C. Zakas
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 'use strict';
-/*eslint-disable*/
 
-module.exports = function luhn10(a,b,c,d,e) {
-  for(d = +a[b = a.length-1], e=0; b--;)
-  c = +a[b], d += ++e % 2 ? 2 * c % 10 + (c > 4) : c;
-  return !(d%10)
-};
+function luhn10(identifier) {
+  var sum = 0;
+  var alt = false;
+  var i = identifier.length - 1;
+  var num;
+
+  while (i >= 0) {
+    num = parseInt(identifier.charAt(i), 10);
+
+    if (alt) {
+      num *= 2;
+      if (num > 9) {
+        num = (num % 10) + 1; // eslint-disable-line no-extra-parens
+      }
+    }
+
+    alt = !alt;
+
+    sum += num;
+
+    i--;
+  }
+
+  return sum % 10 === 0;
+}
+
+module.exports = luhn10;


### PR DESCRIPTION
The previous implementation, while quite clever, left much to be desired in
terms of readability.

The version included in this commit has been lifted from Nicolas C. Zakas's
(@nzakas) "Computer Science in Javascript" GitHub repository with two changes:

1. Small style changes to accommodate ESLint.
2. The removal of an `isNan()` check on each digit which is unnecessary given
   the RegEx validation done earlier in `card-number.js`.

The original source, and its permissive licence, can be found here:
https://github.com/nzakas/computer-science-in-javascript/blob/master/algorithms/checksums/luhn-algorithm/luhn-algorithm.js

According to the build script, this change increases minified build size by
a negligible 0.04 kB:

    // Before
    [10:12:50] all files 12.89 kB

    // After
    [10:12:21] all files 12.93 kB