### PR TITLE
Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,27 +252,57 @@ A fake session where a user is entering a card number may look like:
 
 - - -
 
-#### `valid.expirationMonth(value: string): boolean`
+#### `valid.expirationMonth(value: string): object`
 
 `expirationMonth` accepts 1 or 2 digit months. `1`, `01`, `10` are all valid entries.
 
+```javascript
+{
+  isValidForThisYear: false,
+  isPotentiallyValid: true,
+  isValid: true
+}
+```
+
 - - -
 
-#### `valid.expirationYear(value: string): boolean`
+#### `valid.expirationYear(value: string): object`
 
 `expirationYear` accepts 2 or 4 digit years. `16` and `2016` are both valid entries.
 
+```javascript
+{
+  isCurrentYear: false,
+  isPotentiallyValid: true,
+  isValid: true
+}
+```
+
 - - -
 
-#### `valid.cvv(value: string, maxLength: integer): boolean`
+#### `valid.cvv(value: string, maxLength: integer): object`
 
 The `cvv` validation by default tests for a numeric string of 3 characters in length. The `maxLength` can be overridden by passing in an `integer` as a second argument. You would typically switch this length from 3 to 4 in the case of an American Express card which expects a 4 digit CID.
 
+```javascript
+{
+  isPotentiallyValid: true,
+  isValid: true
+}
+```
+
 - - -
 
-#### `valid.postalCode(value: string): boolean`
+#### `valid.postalCode(value: string): object`
 
 The `postalCode` validation essentially tests for a valid string greater than 3 characters in length.
+
+```javascript
+{
+  isPotentiallyValid: true,
+  isValid: true
+}
+```
 
 ## Design decisions
 

--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ The `postalCode` validation essentially tests for a valid string greater than 3 
 
 - The maximum expiration year is 19 years from now. ([view in source](src/expiration-year.js))
 - `valid.expirationDate` will only return `month:` and `year:` as strings if the two are valid, otherwise they will be `null`.
+- Since non-US postal codes are alpha-numeric, the `postalCode` will allow non-number characters to be used in validation.
 
 ## Development
 


### PR DESCRIPTION
Closes #31

Our documentation around return values was incorrect. We stated that we returned boolean values when in fact we return objects with information about potential validity and validity.

Also added a note about non-numeric characters in postal codes under design decisions.