### PR TITLE
Remove unused `namespace` key from Gulp configuration

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,7 +10,6 @@ var rename = require('gulp-rename');
 var del = require('del');
 
 var config = {
-  namespace: 'braintree',
   src: {
     js: {
       all: './src/**/*.js',


### PR DESCRIPTION
This key seems unneeded so we removed it.