### PR TITLE
Remove Lodash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ unreleased
 ==========
 
 - __Breaking change__: Remove `dist` files. You must use `npm` to use this module
+- __Breaking change__: Remove support for primitive constructors like `new String()`
+- __Breaking change__: Drop support for Internet Explorer 8
 
 3.0.1
 =====

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@ unreleased
 
 - __Breaking change__: Remove `dist` files. You must use `npm` to use this module
 - __Breaking change__: Remove support for primitive constructors like `new String()`
-- __Breaking change__: Drop support for Internet Explorer 8
 
 3.0.1
 =====

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "sinon-chai": "^2.7.0"
   },
   "dependencies": {
-    "credit-card-type": "^5.0.0",
-    "lodash": "3.10.1"
+    "credit-card-type": "^5.0.0"
   }
 }

--- a/src/card-number.js
+++ b/src/card-number.js
@@ -1,23 +1,20 @@
 'use strict';
 
-var isString = require('lodash/lang/isString');
-var extend = require('lodash/object/assign');
 var luhn10 = require('./luhn-10');
 var getCardTypes = require('credit-card-type');
-var isNumber = require('lodash/lang/isNumber');
 
 function verification(card, isPotentiallyValid, isValid) {
-  return extend({}, {card: card, isPotentiallyValid: isPotentiallyValid, isValid: isValid});
+  return {card: card, isPotentiallyValid: isPotentiallyValid, isValid: isValid};
 }
 
 function cardNumber(value) {
   var potentialTypes, cardType, isPotentiallyValid, isValid, i, maxLength;
 
-  if (isNumber(value)) {
+  if (typeof value === 'number') {
     value = String(value);
   }
 
-  if (!isString(value)) { return verification(null, false, false); }
+  if (typeof value !== 'string') { return verification(null, false, false); }
 
   value = value.replace(/\-|\s/g, '');
 

--- a/src/cvv.js
+++ b/src/cvv.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var isString = require('lodash/lang/isString');
 var DEFAULT_LENGTH = 3;
 
 function includes(array, thing) {
@@ -32,7 +31,7 @@ function cvv(value, maxLength) {
   maxLength = maxLength || DEFAULT_LENGTH;
   maxLength = maxLength instanceof Array ? maxLength : [maxLength];
 
-  if (!isString(value)) { return verification(false, false); }
+  if (typeof value !== 'string') { return verification(false, false); }
   if (!/^\d*$/.test(value)) { return verification(false, false); }
   if (includes(maxLength, value.length)) { return verification(true, true); }
   if (value.length < Math.min.apply(null, maxLength)) { return verification(false, true); }

--- a/src/expiration-date.js
+++ b/src/expiration-date.js
@@ -3,7 +3,6 @@
 var parseDate = require('./parse-date');
 var expirationMonth = require('./expiration-month');
 var expirationYear = require('./expiration-year');
-var isString = require('lodash/lang/isString');
 
 function verification(isValid, isPotentiallyValid, month, year) {
   return {
@@ -17,7 +16,7 @@ function verification(isValid, isPotentiallyValid, month, year) {
 function expirationDate(value) {
   var date, monthValid, yearValid, isValidForThisYear;
 
-  if (isString(value)) {
+  if (typeof value === 'string') {
     value = value.replace(/^(\d\d) (\d\d(\d\d)?)$/, '$1/$2');
     date = parseDate(value);
   } else if (value !== null && typeof value === 'object') {

--- a/src/expiration-month.js
+++ b/src/expiration-month.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var isString = require('lodash/lang/isString');
-
 function verification(isValid, isPotentiallyValid, isValidForThisYear) {
   return {
     isValid: isValid,
@@ -14,7 +12,7 @@ function expirationMonth(value) {
   var month, result;
   var currentMonth = new Date().getMonth() + 1;
 
-  if (!isString(value)) {
+  if (typeof value !== 'string') {
     return verification(false, false);
   }
   if (value.replace(/\s/g, '') === '' || value === '0') {

--- a/src/expiration-year.js
+++ b/src/expiration-year.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var isString = require('lodash/lang/isString');
 var maxYear = 19;
 
 function verification(isValid, isPotentiallyValid, isCurrentYear) {
@@ -14,7 +13,7 @@ function verification(isValid, isPotentiallyValid, isCurrentYear) {
 function expirationYear(value) {
   var currentFirstTwo, currentYear, firstTwo, len, twoDigitYear, valid, isCurrentYear;
 
-  if (!isString(value)) {
+  if (typeof value !== 'string') {
     return verification(false, false);
   }
   if (value.replace(/\s/g, '') === '') {

--- a/src/lib/is-array.js
+++ b/src/lib/is-array.js
@@ -1,5 +1,7 @@
 'use strict';
 
+// Polyfill taken from <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray#Polyfill>.
+
 module.exports = Array.isArray || function (arg) {
   return Object.prototype.toString.call(arg) === '[object Array]';
 };

--- a/src/lib/is-array.js
+++ b/src/lib/is-array.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = Array.isArray || function (arg) {
+  return Object.prototype.toString.call(arg) === '[object Array]';
+};

--- a/src/parse-date.js
+++ b/src/parse-date.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var expirationYear = require('./expiration-year');
+var isArray = require('./lib/is-array');
 
 function parseDate(value) {
   var month, len, year, yearValid;
@@ -11,7 +12,7 @@ function parseDate(value) {
     value = value.split(/ +/g);
   }
 
-  if (Array.isArray(value)) {
+  if (isArray(value)) {
     return {
       month: value[0],
       year: value.slice(1).join()

--- a/src/parse-date.js
+++ b/src/parse-date.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var expirationYear = require('./expiration-year');
-var isArray = require('lodash/lang/isArray');
 
 function parseDate(value) {
   var month, len, year, yearValid;
@@ -12,7 +11,7 @@ function parseDate(value) {
     value = value.split(/ +/g);
   }
 
-  if (isArray(value)) {
+  if (Array.isArray(value)) {
     return {
       month: value[0],
       year: value.slice(1).join()

--- a/src/postal-code.js
+++ b/src/postal-code.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var isString = require('lodash/lang/isString');
 var MIN_POSTAL_CODE_LENGTH = 3;
 
 function verification(isValid, isPotentiallyValid) {
@@ -8,7 +7,7 @@ function verification(isValid, isPotentiallyValid) {
 }
 
 function postalCode(value) {
-  if (!isString(value)) {
+  if (typeof value !== 'string') {
     return verification(false, false);
   } else if (value.length < MIN_POSTAL_CODE_LENGTH) {
     return verification(false, true);

--- a/test/unit/lib/is-array.js
+++ b/test/unit/lib/is-array.js
@@ -1,0 +1,25 @@
+'use strict';
+
+var isArray = require('../../../src/lib/is-array');
+var expect = require('chai').expect;
+
+describe('isArray', function () {
+  it('returns true for arrays', function () {
+    expect(isArray([])).to.equal(true);
+    expect(isArray([1, 2])).to.equal(true);
+    expect(isArray([null])).to.equal(true);
+  });
+
+  it('returns false for non-arrays', function () {
+    expect(isArray()).to.equal(false);
+    expect(isArray(undefined)).to.equal(false);  // eslint-disable-line no-undefined
+    expect(isArray(null)).to.equal(false);
+    expect(isArray(true)).to.equal(false);
+    expect(isArray(false)).to.equal(false);
+    expect(isArray(0)).to.equal(false);
+    expect(isArray(1)).to.equal(false);
+    expect(isArray('arr')).to.equal(false);
+    expect(isArray({})).to.equal(false);
+    expect(isArray({length: 2})).to.equal(false);
+  });
+});


### PR DESCRIPTION
This replaces things like `lodash/lang/isString` with things like `typeof value === 'string'`. This only affects people doing the verboten `new String` stuff, which should never be done.

This also turns a Lodash `isArray` into an `Array.isArray`. This breaks IE8 compatibility, which could be an issue.