### PR TITLE
Allow min length configuration for postal code validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+UNRELEASED
+==========
+
+- Add options object for postal code validation to specify min length
+
 4.0.0
 =====
 

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ The `cvv` validation by default tests for a numeric string of 3 characters in le
 
 - - -
 
-#### `valid.postalCode(value: string): object`
+#### `valid.postalCode(value: string, [options: object]): object`
 
 The `postalCode` validation essentially tests for a valid string greater than 3 characters in length.
 
@@ -283,6 +283,17 @@ The `postalCode` validation essentially tests for a valid string greater than 3 
 {
   isPotentiallyValid: true,
   isValid: true
+}
+```
+
+You can optionally pass `minLength` as a property of an object as a second argument. This will override the default min length of 3.
+
+```javascript
+valid.postalCode('123', {minLength: 5});
+
+{
+  isPotentiallyValid: true,
+  isValid: false
 }
 ```
 

--- a/src/postal-code.js
+++ b/src/postal-code.js
@@ -1,15 +1,21 @@
 'use strict';
 
-var MIN_POSTAL_CODE_LENGTH = 3;
+var DEFAULT_MIN_POSTAL_CODE_LENGTH = 3;
 
 function verification(isValid, isPotentiallyValid) {
   return {isValid: isValid, isPotentiallyValid: isPotentiallyValid};
 }
 
-function postalCode(value) {
+function postalCode(value, options) {
+  var minLength;
+
+  options = options || {};
+
+  minLength = options.minLength || DEFAULT_MIN_POSTAL_CODE_LENGTH;
+
   if (typeof value !== 'string') {
     return verification(false, false);
-  } else if (value.length < MIN_POSTAL_CODE_LENGTH) {
+  } else if (value.length < minLength) {
     return verification(false, true);
   }
 

--- a/test/unit/postal-code.js
+++ b/test/unit/postal-code.js
@@ -59,11 +59,26 @@ describe('postalCode', function () {
   });
 
   describe('custom min length', function () {
-    it('allows passing in a custom min length', function () {
+    it('uses default min length when no minLength option is passed', function () {
       expect(postalCode('123')).to.deep.equal({
         isValid: true,
         isPotentiallyValid: true
       });
+      expect(postalCode('123', {})).to.deep.equal({
+        isValid: true,
+        isPotentiallyValid: true
+      });
+      expect(postalCode('12')).to.deep.equal({
+        isValid: false,
+        isPotentiallyValid: true
+      });
+      expect(postalCode('12', {})).to.deep.equal({
+        isValid: false,
+        isPotentiallyValid: true
+      });
+    });
+
+    it('allows passing in a custom min length', function () {
       expect(postalCode('123', {minLength: 4})).to.deep.equal({
         isValid: false,
         isPotentiallyValid: true

--- a/test/unit/postal-code.js
+++ b/test/unit/postal-code.js
@@ -57,4 +57,21 @@ describe('postalCode', function () {
       });
     });
   });
+
+  describe('custom min length', function () {
+    it('allows passing in a custom min length', function () {
+      expect(postalCode('123')).to.deep.equal({
+        isValid: true,
+        isPotentiallyValid: true
+      });
+      expect(postalCode('123', {minLength: 4})).to.deep.equal({
+        isValid: false,
+        isPotentiallyValid: true
+      });
+      expect(postalCode('1234', {minLength: 4})).to.deep.equal({
+        isValid: true,
+        isPotentiallyValid: true
+      });
+    });
+  });
 });


### PR DESCRIPTION
Add option for min length in postal code validation.