### PR TITLE
Allow max year configuration for expirationDate validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,9 @@ A fake session where a user is entering a card number may look like:
 
 - - -
 
-#### `valid.expirationDate(value: string|object): object`
+#### `valid.expirationDate(value: string|object, maxElapsedYear: integer): object`
+
+The `maxElapsedYear` can be overridden by passing in an `integer` as a second argument.
 
 ```javascript
 {

--- a/README.md
+++ b/README.md
@@ -246,9 +246,9 @@ A fake session where a user is entering a card number may look like:
 
 - - -
 
-#### `valid.expirationYear(value: string): object`
+#### `valid.expirationYear(value: string, maxElapsedYear: integer): object`
 
-`expirationYear` accepts 2 or 4 digit years. `16` and `2016` are both valid entries.
+`expirationYear` accepts 2 or 4 digit years. `16` and `2016` are both valid entries. The `maxElapsedYear` can be overridden by passing in an `integer` as a second argument.
 
 ```javascript
 {
@@ -297,7 +297,7 @@ valid.postalCode('123', {minLength: 5});
 
 ## Design decisions
 
-- The maximum expiration year is 19 years from now. ([view in source](src/expiration-year.js))
+- The default maximum expiration year is 19 years from now. ([view in source](src/expiration-year.js))
 - `valid.expirationDate` will only return `month:` and `year:` as strings if the two are valid, otherwise they will be `null`.
 - Since non-US postal codes are alpha-numeric, the `postalCode` will allow non-number characters to be used in validation.
 

--- a/src/expiration-date.js
+++ b/src/expiration-date.js
@@ -13,7 +13,7 @@ function verification(isValid, isPotentiallyValid, month, year) {
   };
 }
 
-function expirationDate(value) {
+function expirationDate(value, maxElapsedYear) {
   var date, monthValid, yearValid, isValidForThisYear;
 
   if (typeof value === 'string') {
@@ -29,7 +29,7 @@ function expirationDate(value) {
   }
 
   monthValid = expirationMonth(date.month);
-  yearValid = expirationYear(date.year);
+  yearValid = expirationYear(date.year, maxElapsedYear);
 
   if (monthValid.isValid) {
     if (yearValid.isCurrentYear) {

--- a/src/expiration-year.js
+++ b/src/expiration-year.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var maxYear = 19;
+var DEFAULT_MAX_ELAPSED_YEAR = 19;
 
 function verification(isValid, isPotentiallyValid, isCurrentYear) {
   return {
@@ -10,8 +10,10 @@ function verification(isValid, isPotentiallyValid, isCurrentYear) {
   };
 }
 
-function expirationYear(value) {
+function expirationYear(value, maxElapsedYear) {
   var currentFirstTwo, currentYear, firstTwo, len, twoDigitYear, valid, isCurrentYear;
+
+  maxElapsedYear = maxElapsedYear || DEFAULT_MAX_ELAPSED_YEAR;
 
   if (typeof value !== 'string') {
     return verification(false, false);
@@ -47,10 +49,10 @@ function expirationYear(value) {
 
   if (len === 2) {
     isCurrentYear = twoDigitYear === value;
-    valid = value >= twoDigitYear && value <= twoDigitYear + maxYear;
+    valid = value >= twoDigitYear && value <= twoDigitYear + maxElapsedYear;
   } else if (len === 4) {
     isCurrentYear = currentYear === value;
-    valid = value >= currentYear && value <= currentYear + maxYear;
+    valid = value >= currentYear && value <= currentYear + maxElapsedYear;
   }
 
   return verification(valid, valid, isCurrentYear);

--- a/test/unit/expiration-date.js
+++ b/test/unit/expiration-date.js
@@ -11,6 +11,10 @@ var currentMonth = date.getMonth() + 1;
 var previousMonth = currentMonth - 1 || currentMonth;
 var nextMonth = currentMonth === 12 ? currentMonth : currentMonth + 1;
 
+function yearsFromNow(fromNow) {
+  return String(currentYear + fromNow);
+}
+
 describe('expirationDate validates', function () {
   context('String Argument', function () {
     var describes = {
@@ -212,6 +216,21 @@ describe('expirationDate validates', function () {
             expect(expirationDate(arg)).to.deep.equal(output);
           });
         });
+      });
+    });
+
+    describe('maxElapsedYear', function () {
+      it('defaults maxElapsedYear is 19', function () {
+        expect(expirationDate(currentMonth + ' / ' + yearsFromNow(19))).to.deep.equal({isValid: true, isPotentiallyValid: true, month: currentMonth.toString(), year: yearsFromNow(19).toString()});
+        expect(expirationDate(currentMonth + ' / ' + yearsFromNow(20))).to.deep.equal({isValid: false, isPotentiallyValid: false, month: null, year: null});
+      });
+
+      it('accepts maxElapsedYear', function () {
+        expect(expirationDate(currentMonth + ' / ' + yearsFromNow(20), 20)).to.deep.equal({isValid: true, isPotentiallyValid: true, month: currentMonth.toString(), year: yearsFromNow(20).toString()});
+      });
+
+      it('returns invalid if beyond maxElapsedYear', function () {
+        expect(expirationDate(currentMonth + ' / ' + yearsFromNow(21), 20)).to.deep.equal({isValid: false, isPotentiallyValid: false, month: null, year: null});
       });
     });
   });

--- a/test/unit/expiration-year.js
+++ b/test/unit/expiration-year.js
@@ -14,93 +14,110 @@ function yearsFromNow(fromNow, digits) {
 }
 
 describe('expirationYear', function () {
-  var FALSE_VALIDATION = {isValid: false, isPotentiallyValid: false, isCurrentYear: false};
+  describe('value', function () {
+    var FALSE_VALIDATION = {isValid: false, isPotentiallyValid: false, isCurrentYear: false};
 
-  var describes = {
-    'returns false if not a string': [
-      [[], FALSE_VALIDATION],
-      [{}, FALSE_VALIDATION],
-      [null, FALSE_VALIDATION],
-      [undefined, FALSE_VALIDATION], // eslint-disable-line no-undefined
-      [Infinity, FALSE_VALIDATION],
-      [0 / 0, FALSE_VALIDATION],
-      [0, FALSE_VALIDATION],
-      [1, FALSE_VALIDATION],
-      [2, FALSE_VALIDATION],
-      [12, FALSE_VALIDATION],
-      [-1, FALSE_VALIDATION],
-      [-12, FALSE_VALIDATION]
-    ],
+    var describes = {
+      'returns false if not a string': [
+        [[], FALSE_VALIDATION],
+        [{}, FALSE_VALIDATION],
+        [null, FALSE_VALIDATION],
+        [undefined, FALSE_VALIDATION], // eslint-disable-line no-undefined
+        [Infinity, FALSE_VALIDATION],
+        [0 / 0, FALSE_VALIDATION],
+        [0, FALSE_VALIDATION],
+        [1, FALSE_VALIDATION],
+        [2, FALSE_VALIDATION],
+        [12, FALSE_VALIDATION],
+        [-1, FALSE_VALIDATION],
+        [-12, FALSE_VALIDATION]
+      ],
 
-    'returns false for malformed strings': [
-      ['foo', FALSE_VALIDATION],
-      ['1.2', FALSE_VALIDATION],
-      ['1/20', FALSE_VALIDATION],
-      ['1 2', FALSE_VALIDATION],
-      ['1 ', FALSE_VALIDATION],
-      [' 1', FALSE_VALIDATION],
-      ['20015', FALSE_VALIDATION]
-    ],
+      'returns false for malformed strings': [
+        ['foo', FALSE_VALIDATION],
+        ['1.2', FALSE_VALIDATION],
+        ['1/20', FALSE_VALIDATION],
+        ['1 2', FALSE_VALIDATION],
+        ['1 ', FALSE_VALIDATION],
+        [' 1', FALSE_VALIDATION],
+        ['20015', FALSE_VALIDATION]
+      ],
 
-    'returns the appropriate values for incomplete strings': [
-      ['', {isValid: false, isPotentiallyValid: true, isCurrentYear: false}],
-      ['2', {isValid: false, isPotentiallyValid: true, isCurrentYear: false}],
-      ['9', {isValid: false, isPotentiallyValid: true, isCurrentYear: false}],
-      ['200', {isValid: false, isPotentiallyValid: true, isCurrentYear: false}],
-      ['123', {isValid: false, isPotentiallyValid: false, isCurrentYear: false}]
-    ],
+      'returns the appropriate values for incomplete strings': [
+        ['', {isValid: false, isPotentiallyValid: true, isCurrentYear: false}],
+        ['2', {isValid: false, isPotentiallyValid: true, isCurrentYear: false}],
+        ['9', {isValid: false, isPotentiallyValid: true, isCurrentYear: false}],
+        ['200', {isValid: false, isPotentiallyValid: true, isCurrentYear: false}],
+        ['123', {isValid: false, isPotentiallyValid: false, isCurrentYear: false}]
+      ],
 
-    'accepts four-digit years': [
-      [yearsFromNow(0), {isValid: true, isPotentiallyValid: true, isCurrentYear: true}],
-      [yearsFromNow(-5), {isValid: false, isPotentiallyValid: false, isCurrentYear: false}],
-      [yearsFromNow(5), {isValid: true, isPotentiallyValid: true, isCurrentYear: false}],
-      [yearsFromNow(10), {isValid: true, isPotentiallyValid: true, isCurrentYear: false}],
-      [yearsFromNow(11), {isValid: true, isPotentiallyValid: true, isCurrentYear: false}],
-      [yearsFromNow(12), {isValid: true, isPotentiallyValid: true, isCurrentYear: false}],
-      [yearsFromNow(19), {isValid: true, isPotentiallyValid: true, isCurrentYear: false}],
-      [yearsFromNow(20), {isValid: false, isPotentiallyValid: false, isCurrentYear: false}],
-      [yearsFromNow(25), {isValid: false, isPotentiallyValid: false, isCurrentYear: false}],
-      [yearsFromNow(33), {isValid: false, isPotentiallyValid: false, isCurrentYear: false}]
-    ],
+      'accepts four-digit years': [
+        [yearsFromNow(0), {isValid: true, isPotentiallyValid: true, isCurrentYear: true}],
+        [yearsFromNow(-5), {isValid: false, isPotentiallyValid: false, isCurrentYear: false}],
+        [yearsFromNow(5), {isValid: true, isPotentiallyValid: true, isCurrentYear: false}],
+        [yearsFromNow(10), {isValid: true, isPotentiallyValid: true, isCurrentYear: false}],
+        [yearsFromNow(11), {isValid: true, isPotentiallyValid: true, isCurrentYear: false}],
+        [yearsFromNow(12), {isValid: true, isPotentiallyValid: true, isCurrentYear: false}],
+        [yearsFromNow(19), {isValid: true, isPotentiallyValid: true, isCurrentYear: false}],
+        [yearsFromNow(20), {isValid: false, isPotentiallyValid: false, isCurrentYear: false}],
+        [yearsFromNow(25), {isValid: false, isPotentiallyValid: false, isCurrentYear: false}],
+        [yearsFromNow(33), {isValid: false, isPotentiallyValid: false, isCurrentYear: false}]
+      ],
 
-    'accepts two-digit years': [
-      [yearsFromNow(0, 2), {isValid: true, isPotentiallyValid: true, isCurrentYear: true}],
-      [yearsFromNow(-5, 2), {isValid: false, isPotentiallyValid: false, isCurrentYear: false}],
-      [yearsFromNow(5, 2), {isValid: true, isPotentiallyValid: true, isCurrentYear: false}],
-      [yearsFromNow(10, 2), {isValid: true, isPotentiallyValid: true, isCurrentYear: false}],
-      [yearsFromNow(11, 2), {isValid: true, isPotentiallyValid: true, isCurrentYear: false}],
-      [yearsFromNow(12, 2), {isValid: true, isPotentiallyValid: true, isCurrentYear: false}],
-      [yearsFromNow(19, 2), {isValid: true, isPotentiallyValid: true, isCurrentYear: false}],
-      [yearsFromNow(20, 2), {isValid: false, isPotentiallyValid: false, isCurrentYear: false}],
-      [yearsFromNow(25, 2), {isValid: false, isPotentiallyValid: false, isCurrentYear: false}],
-      [yearsFromNow(33, 2), {isValid: false, isPotentiallyValid: false, isCurrentYear: false}]
-    ],
+      'accepts two-digit years': [
+        [yearsFromNow(0, 2), {isValid: true, isPotentiallyValid: true, isCurrentYear: true}],
+        [yearsFromNow(-5, 2), {isValid: false, isPotentiallyValid: false, isCurrentYear: false}],
+        [yearsFromNow(5, 2), {isValid: true, isPotentiallyValid: true, isCurrentYear: false}],
+        [yearsFromNow(10, 2), {isValid: true, isPotentiallyValid: true, isCurrentYear: false}],
+        [yearsFromNow(11, 2), {isValid: true, isPotentiallyValid: true, isCurrentYear: false}],
+        [yearsFromNow(12, 2), {isValid: true, isPotentiallyValid: true, isCurrentYear: false}],
+        [yearsFromNow(19, 2), {isValid: true, isPotentiallyValid: true, isCurrentYear: false}],
+        [yearsFromNow(20, 2), {isValid: false, isPotentiallyValid: false, isCurrentYear: false}],
+        [yearsFromNow(25, 2), {isValid: false, isPotentiallyValid: false, isCurrentYear: false}],
+        [yearsFromNow(33, 2), {isValid: false, isPotentiallyValid: false, isCurrentYear: false}]
+      ],
 
-    // This doesn't take 20xx -> 21xx into account, but probably YAGNI
-    'accepts three-digit years': [
-      [yearsFromNow(-3).slice(0, 3), {isValid: false, isPotentiallyValid: true, isCurrentYear: false}],
-      [yearsFromNow(-1).slice(0, 3), {isValid: false, isPotentiallyValid: true, isCurrentYear: false}],
-      [yearsFromNow(0).slice(0, 3), {isValid: false, isPotentiallyValid: true, isCurrentYear: false}],
-      [yearsFromNow(1).slice(0, 3), {isValid: false, isPotentiallyValid: true, isCurrentYear: false}],
-      [yearsFromNow(5).slice(0, 3), {isValid: false, isPotentiallyValid: true, isCurrentYear: false}],
-      [yearsFromNow(11).slice(0, 3), {isValid: false, isPotentiallyValid: true, isCurrentYear: false}],
-      [yearsFromNow(17).slice(0, 3), {isValid: false, isPotentiallyValid: true, isCurrentYear: false}],
-      [yearsFromNow(23).slice(0, 3), {isValid: false, isPotentiallyValid: true, isCurrentYear: false}]
-    ]
-  };
+      // This doesn't take 20xx -> 21xx into account, but probably YAGNI
+      'accepts three-digit years': [
+        [yearsFromNow(-3).slice(0, 3), {isValid: false, isPotentiallyValid: true, isCurrentYear: false}],
+        [yearsFromNow(-1).slice(0, 3), {isValid: false, isPotentiallyValid: true, isCurrentYear: false}],
+        [yearsFromNow(0).slice(0, 3), {isValid: false, isPotentiallyValid: true, isCurrentYear: false}],
+        [yearsFromNow(1).slice(0, 3), {isValid: false, isPotentiallyValid: true, isCurrentYear: false}],
+        [yearsFromNow(5).slice(0, 3), {isValid: false, isPotentiallyValid: true, isCurrentYear: false}],
+        [yearsFromNow(11).slice(0, 3), {isValid: false, isPotentiallyValid: true, isCurrentYear: false}],
+        [yearsFromNow(17).slice(0, 3), {isValid: false, isPotentiallyValid: true, isCurrentYear: false}],
+        [yearsFromNow(23).slice(0, 3), {isValid: false, isPotentiallyValid: true, isCurrentYear: false}]
+      ]
+    };
 
-  Object.keys(describes).forEach(function (key) {
-    var tests = describes[key];
+    Object.keys(describes).forEach(function (key) {
+      var tests = describes[key];
 
-    describe(key, function () {
-      tests.forEach(function (test) {
-        var arg = test[0];
-        var output = test[1];
+      describe(key, function () {
+        tests.forEach(function (test) {
+          var arg = test[0];
+          var output = test[1];
 
-        it('returns ' + JSON.stringify(output) + ' for "' + arg + '"', function () {
-          expect(expirationYear(arg)).to.deep.equal(output);
+          it('returns ' + JSON.stringify(output) + ' for "' + arg + '"', function () {
+            expect(expirationYear(arg)).to.deep.equal(output);
+          });
         });
       });
+    });
+  });
+
+  describe('maxElapsedYear', function () {
+    it('defaults maxElapsedYear is 19', function () {
+      expect(expirationYear(yearsFromNow(19))).to.deep.equal({isValid: true, isPotentiallyValid: true, isCurrentYear: false});
+      expect(expirationYear(yearsFromNow(20))).to.deep.equal({isValid: false, isPotentiallyValid: false, isCurrentYear: false});
+    });
+
+    it('accepts maxElapsedYear', function () {
+      expect(expirationYear(yearsFromNow(20), 20)).to.deep.equal({isValid: true, isPotentiallyValid: true, isCurrentYear: false});
+    });
+
+    it('returns invalid if beyond maxElapsedYear', function () {
+      expect(expirationYear(yearsFromNow(21), 20)).to.deep.equal({isValid: false, isPotentiallyValid: false, isCurrentYear: false});
     });
   });
 });


### PR DESCRIPTION
## Motivation
>https://stackoverflow.com/questions/2500588/maximum-year-in-expiry-date-of-credit-card
>Various online services have different values for maximum year of expiry, when it comes to Credit Cards.
>For instance:
>* Basecamp: +15 years (2025)
>* Amazon: +20 years (2030)
>* Paypal: +19 years (2029)

I want to customize the maximum year of expiry for my service too.