### PR TITLE
Expose credit-card-type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+unreleased
+==========
+
+- Support custom card brands
+- Require minimum version of credit-card-type to be v6.2.0
+
 4.2.0
 =====
 

--- a/README.md
+++ b/README.md
@@ -299,6 +299,25 @@ valid.postalCode('123', {minLength: 5});
 }
 ```
 
+## Custom Card Brands
+
+Card Validator exposes the [`credit-card-type` module](https://github.com/braintree/credit-card-type) as `creditCardType`. You can add custom card brands by [utilizing the `addCard` method](https://github.com/braintree/credit-card-type#adding-card-types).
+
+```javascript
+valid.creditCardType.addCard({
+  niceType: 'NewCard',
+  type: 'new-card',
+  prefixPattern: /^(2|23|234)$/,
+  exactPattern: /^(2345)\d*$/,
+  gaps: [4, 8, 12],
+  lengths: [16],
+  code: {
+    name: 'CVV',
+    size: 3
+  }
+});
+```
+
 ## Design decisions
 
 - The default maximum expiration year is 19 years from now.

--- a/index.js
+++ b/index.js
@@ -6,5 +6,6 @@ module.exports = {
   expirationMonth: require('./src/expiration-month'),
   expirationYear: require('./src/expiration-year'),
   cvv: require('./src/cvv'),
-  postalCode: require('./src/postal-code')
+  postalCode: require('./src/postal-code'),
+  creditCardType: require('credit-card-type')
 };

--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
     "sinon-chai": "^2.7.0"
   },
   "dependencies": {
-    "credit-card-type": "^6.0.0"
+    "credit-card-type": "^6.2.0"
   }
 }

--- a/test/unit/credit-card-type.js
+++ b/test/unit/credit-card-type.js
@@ -1,0 +1,11 @@
+'use strict';
+
+var expect = require('chai').expect;
+var cardValidator = require('../../');
+var creditCardType = require('credit-card-type');
+
+describe('creditCardType', function () {
+  it('exposes creditCardType', function () {
+    expect(cardValidator.creditCardType).to.equal(creditCardType);
+  });
+});


### PR DESCRIPTION
closes #56 

Allows developers to set custom card brands via: https://github.com/braintree/credit-card-type#adding-card-types