### PR TITLE
Add validate union pay option and update tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 =====
 
 - Add optional options object with `luhnValidateUnionPay` parameter to force luhn validity check of UnionPay cards
+- Update tests to account for ELO cards
 
 5.0.0
 =====

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+5.1.0
+=====
+
+- Add optional options object with `luhnValidateUnionPay` parameter to force luhn validity check of UnionPay cards
+
 5.0.0
 =====
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ if (numberValidation.card) {
 
 - - -
 
-#### `valid.number(value: string): object`
+#### `valid.number(value: string, [options: object]): object`
 
 ```javascript
 {
@@ -51,6 +51,24 @@ if (numberValidation.card) {
   },
   isPotentiallyValid: true, // if false, indicates there is no way the card could be valid
   isValid: true // if true, number is valid for submission
+}
+```
+
+You can optionally pass `luhnValidateUnionPay` as a property of an object as a second argument. This will override the default behavior to ignore luhn validity of UnionPay cards.
+
+```javascript
+valid.number(<Luhn Invalid UnionPay Card Number>, {luhnValidateUnionPay: true});
+
+{
+  card: {
+    niceType: 'UnionPay',
+    type: 'unionpay',
+    gaps: [4, 8, 12],
+    lengths: [16, 17, 18, 19],
+    code: {name: 'CVN', size: 3}
+  },
+  isPotentiallyValid: true,
+  isValid: false // Would be true if no options were included
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "card-validator",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "A library for validating credit card fields",
   "main": "index.js",
   "repository": {

--- a/src/card-number.js
+++ b/src/card-number.js
@@ -7,8 +7,10 @@ function verification(card, isPotentiallyValid, isValid) {
   return {card: card, isPotentiallyValid: isPotentiallyValid, isValid: isValid};
 }
 
-function cardNumber(value) {
+function cardNumber(value, options) {
   var potentialTypes, cardType, isPotentiallyValid, isValid, i, maxLength;
+
+  options = options || {};
 
   if (typeof value === 'number') {
     value = String(value);
@@ -30,7 +32,7 @@ function cardNumber(value) {
 
   cardType = potentialTypes[0];
 
-  if (cardType.type === getCardTypes.types.UNIONPAY) {  // UnionPay is not Luhn 10 compliant
+  if (cardType.type === getCardTypes.types.UNIONPAY && options.luhnValidateUnionPay !== true) {
     isValid = true;
   } else {
     isValid = luhn10(value);

--- a/test/unit/card-number.js
+++ b/test/unit/card-number.js
@@ -17,7 +17,7 @@ describe('number validates', function () {
       ['6011',
         {card: 'discover', isPotentiallyValid: true, isValid: false}],
       ['4',
-        {card: 'visa', isPotentiallyValid: true, isValid: false}],
+        {card: null, isPotentiallyValid: true, isValid: false}],
       ['41',
         {card: 'visa', isPotentiallyValid: true, isValid: false}],
       ['411',

--- a/test/unit/card-number.js
+++ b/test/unit/card-number.js
@@ -135,6 +135,43 @@ describe('number validates', function () {
     ]);
   });
 
+  describe('UnionPay', function () {
+    table([
+      ['6',
+        {card: null, isPotentiallyValid: true, isValid: false}],
+      ['62',
+        {card: null, isPotentiallyValid: true, isValid: false}],
+      ['623456',
+        {card: 'unionpay', isPotentiallyValid: true, isValid: false}],
+      ['6212345678901232',
+        {card: 'unionpay', isPotentiallyValid: true, isValid: true}]
+    ]);
+
+    context('where card number is luhn invalid', function () {
+      var number = '6212345000000001';
+
+      it('marks card valid by default', function () {
+        var actual = cardNumber(number);
+
+        expect(actual.card.type).to.equal('unionpay');
+        expect(actual.isPotentiallyValid).to.equal(true);
+        expect(actual.isValid).to.equal(true);
+      });
+
+      it('marks card invalid when "luhnValidateUnionPay" is present', function () {
+        var options = {
+          luhnValidateUnionPay: true
+        };
+
+        var actual = cardNumber(number, options);
+
+        expect(actual.card.type).to.equal('unionpay');
+        expect(actual.isPotentiallyValid).to.equal(true);
+        expect(actual.isValid).to.equal(false);
+      });
+    });
+  });
+
   describe('edge cases', function () {
     table([
       ['',


### PR DESCRIPTION
Previously, UnionPay cards skipped luhn validity checks. Now that most of these cards are able to be checked by a luhn algorithm, we've added the ability to change the logic with an options object so that you can selectively reject luhn invalid cards.

Additionally, recent updates to `credit-card-type.js` resulted in the need to update tests.

@braintree/team-dx 