### PR TITLE
Update credit-card-type to v8.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+unreleased
+==========
+
+- Update credit-card-type to v8.0.0
+
+*Breaking Changes*
+
+- When adding or updating cards, this module no longer uses an `exactPattern` and `prefixPattern` model. Instead, it takes an array of patterns. See https://github.com/braintree/credit-card-type#pattern-detection for details.
+
 5.1.0
 =====
 

--- a/README.md
+++ b/README.md
@@ -325,8 +325,9 @@ Card Validator exposes the [`credit-card-type` module](https://github.com/braint
 valid.creditCardType.addCard({
   niceType: 'NewCard',
   type: 'new-card',
-  prefixPattern: /^(2|23|234)$/,
-  exactPattern: /^(2345)\d*$/,
+  patterns: [
+    1234
+  ],
   gaps: [4, 8, 12],
   lengths: [16],
   code: {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
     "sinon-chai": "^2.7.0"
   },
   "dependencies": {
-    "credit-card-type": "^7.0.0"
+    "credit-card-type": "^8.0.0"
   }
 }


### PR DESCRIPTION
closes #64 

Will require a major version bump.