### PR TITLE
Add maxLength option for card number validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+unreleased
+==========
+
+- Add option to set a `maxLength` for card number valiation
+
 6.0.0
 =====
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,20 @@ valid.number(<Luhn Invalid UnionPay Card Number>, {luhnValidateUnionPay: true});
 }
 ```
 
+You can optionally pass `maxLength` as a property of an object as a second argument. This will override the default behavior to use the card type's max length property and mark any cards that exceed the max length as invalid.
+
+```javascript
+valid.number(<Maestro Card with 19 Digits>, {maxLength: 16});
+
+{
+  card: {
+    // Maestro card data
+  },
+  isPotentiallyValid: false,
+  isValid: false
+}
+```
+
 If a valid card type cannot be determined, the `card` field in the response will be `null`.
 
 A fake session where a user is entering a card number may look like:

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ valid.number(<Luhn Invalid UnionPay Card Number>, {luhnValidateUnionPay: true});
 }
 ```
 
-You can optionally pass `maxLength` as a property of an object as a second argument. This will override the default behavior to use the card type's max length property and mark any cards that exceed the max length as invalid.
+You can optionally pass `maxLength` as a property of an object as a second argument. This will override the default behavior to use the card type's max length property and mark any cards that exceed the max length as invalid. If a card brand has a normal max length that is shorter than the passed in max length, the validator will use the shorter one.
 
 ```javascript
 valid.number(<Maestro Card with 19 Digits>, {maxLength: 16});

--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ valid.number(<Luhn Invalid UnionPay Card Number>, {luhnValidateUnionPay: true});
 }
 ```
 
-You can optionally pass `maxLength` as a property of an object as a second argument. This will override the default behavior to use the card type's max length property and mark any cards that exceed the max length as invalid. If a card brand has a normal max length that is shorter than the passed in max length, the validator will use the shorter one.
+You can optionally pass `maxLength` as a property of an object as a second argument. This will override the default behavior to use the card type's max length property and mark any cards that exceed the max length as invalid.
+
+If a card brand has a normal max length that is shorter than the passed in max length, the validator will use the shorter one. For instance, if a `maxLength` of `16` is provided, the validator will still use `15` as the max length for American Express cards.
 
 ```javascript
 valid.number(<Maestro Card with 19 Digits>, {maxLength: 16});

--- a/src/card-number.js
+++ b/src/card-number.js
@@ -42,7 +42,10 @@ function cardNumber(value, options) {
     isValid = luhn10(value);
   }
 
-  maxLength = options.maxLength || Math.max.apply(null, cardType.lengths);
+  maxLength = Math.max.apply(null, cardType.lengths);
+  if (options.maxLength) {
+    maxLength = Math.min(options.maxLength, maxLength);
+  }
 
   for (i = 0; i < cardType.lengths.length; i++) {
     if (cardType.lengths[i] === value.length) {

--- a/src/card-number.js
+++ b/src/card-number.js
@@ -42,11 +42,11 @@ function cardNumber(value, options) {
     isValid = luhn10(value);
   }
 
-  maxLength = Math.max.apply(null, cardType.lengths);
+  maxLength = options.maxLength || Math.max.apply(null, cardType.lengths);
 
   for (i = 0; i < cardType.lengths.length; i++) {
     if (cardType.lengths[i] === value.length) {
-      isPotentiallyValid = value.length !== maxLength || isValid;
+      isPotentiallyValid = value.length < maxLength || isValid;
       return verification(cardType, isPotentiallyValid, isValid);
     }
   }

--- a/src/card-number.js
+++ b/src/card-number.js
@@ -32,6 +32,10 @@ function cardNumber(value, options) {
 
   cardType = potentialTypes[0];
 
+  if (options.maxLength && value.length > options.maxLength) {
+    return verification(cardType, false, false);
+  }
+
   if (cardType.type === getCardTypes.types.UNIONPAY && options.luhnValidateUnionPay !== true) {
     isValid = true;
   } else {

--- a/test/unit/card-number.js
+++ b/test/unit/card-number.js
@@ -195,23 +195,49 @@ describe('number validates', function () {
     ]);
   });
 
-  it('marks card invalid when "maxCardLength" option is used and card is longer than the max length', function () {
-    var options = {
-      maxLength: 16
-    };
+  describe('with "maxCardLength" option', function () {
+    it('marks card invalid when card is longer than the max length', function () {
+      var options = {
+        maxLength: 16
+      };
 
-    var actual = cardNumber('4111 1111 1111 1111 110', options);
+      var actual = cardNumber('4111 1111 1111 1111 110', options);
 
-    expect(actual.card.type).to.equal('visa');
-    expect(actual.isPotentiallyValid).to.equal(false);
-    expect(actual.isValid).to.equal(false);
+      expect(actual.card.type).to.equal('visa');
+      expect(actual.isPotentiallyValid).to.equal(false);
+      expect(actual.isValid).to.equal(false);
 
-    options.maxLength = 19;
-    actual = cardNumber('4111 1111 1111 1111 110', options);
+      options.maxLength = 19;
+      actual = cardNumber('4111 1111 1111 1111 110', options);
 
-    expect(actual.card.type).to.equal('visa');
-    expect(actual.isPotentiallyValid).to.equal(true);
-    expect(actual.isValid).to.equal(true);
+      expect(actual.card.type).to.equal('visa');
+      expect(actual.isPotentiallyValid).to.equal(true);
+      expect(actual.isValid).to.equal(true);
+    });
+
+    it('marks card as not potentially valid when card is equal to max length and not luhn valid', function () {
+      var options = {
+        maxLength: 16
+      };
+
+      var actual = cardNumber('4111 1111 1111 1112', options);
+
+      expect(actual.card.type).to.equal('visa');
+      expect(actual.isPotentiallyValid).to.equal(false);
+      expect(actual.isValid).to.equal(false);
+    });
+
+    it('marks card as valid and potentially valid when card is equal to max length and luhn valid', function () {
+      var options = {
+        maxLength: 16
+      };
+
+      var actual = cardNumber('4111 1111 1111 1111', options);
+
+      expect(actual.card.type).to.equal('visa');
+      expect(actual.isPotentiallyValid).to.equal(true);
+      expect(actual.isValid).to.equal(true);
+    });
   });
 });
 

--- a/test/unit/card-number.js
+++ b/test/unit/card-number.js
@@ -238,6 +238,19 @@ describe('number validates', function () {
       expect(actual.isPotentiallyValid).to.equal(true);
       expect(actual.isValid).to.equal(true);
     });
+
+    it('uses the lesser value for max length if the card brands largest length value is smaller than the configured one', function () {
+      var options = {
+        maxLength: 16
+      };
+
+      // amex has a max length of 15
+      var actual = cardNumber('378282246310005', options);
+
+      expect(actual.card.type).to.equal('american-express');
+      expect(actual.isPotentiallyValid).to.equal(true);
+      expect(actual.isValid).to.equal(true);
+    });
   });
 });
 

--- a/test/unit/card-number.js
+++ b/test/unit/card-number.js
@@ -194,6 +194,25 @@ describe('number validates', function () {
         {card: null, isPotentiallyValid: false, isValid: false}]
     ]);
   });
+
+  it('marks card invalid when "maxCardLength" option is used and card is longer than the max length', function () {
+    var options = {
+      maxLength: 16
+    };
+
+    var actual = cardNumber('4111 1111 1111 1111 110', options);
+
+    expect(actual.card.type).to.equal('visa');
+    expect(actual.isPotentiallyValid).to.equal(false);
+    expect(actual.isValid).to.equal(false);
+
+    options.maxLength = 19;
+    actual = cardNumber('4111 1111 1111 1111 110', options);
+
+    expect(actual.card.type).to.equal('visa');
+    expect(actual.isPotentiallyValid).to.equal(true);
+    expect(actual.isValid).to.equal(true);
+  });
 });
 
 function table(tests) {


### PR DESCRIPTION
Makes it easier to override the default by passing in a `maxLength` option.