### PR TITLE
Documenting v7 breaking changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 _Breaking Changes_
 
+- ES default export no more working:
+  - Must use `import * as cardValidator from 'card-validator'`
+
 - Upgrade credit-card-type to v9.0.0
   - Drop support for card numbers instantiated with `new String(number)`
 


### PR DESCRIPTION
`import cardValidator` from 'card-validator'` used to work (with Webpack 4) and it's no more working for v7 (e.default is undefined).
I think it's a important braking change.