### PR TITLE
ES6-compliant export for vite support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,22 +1,25 @@
-import * as creditCardType from "credit-card-type";
+import * as creditCardTypeFunction from "credit-card-type";
 
 import { cardholderName } from "./cardholder-name";
-import { cardNumber as number } from "./card-number";
+import { cardNumber } from "./card-number";
 import { expirationDate } from "./expiration-date";
 import { expirationMonth } from "./expiration-month";
 import { expirationYear } from "./expiration-year";
 import { cvv } from "./cvv";
 import { postalCode } from "./postal-code";
+import { CreditCardType } from "credit-card-type/dist/types";
 
-const cardValidator = {
+const number = cardNumber;
+const creditCardType: (number: string) => Array<CreditCardType> =
+  creditCardTypeFunction.default;
+export {
   creditCardType,
   cardholderName,
   number,
+  cardNumber,
   expirationDate,
   expirationMonth,
   expirationYear,
   cvv,
   postalCode,
 };
-
-export = cardValidator;


### PR DESCRIPTION
Hi, 

I made this change proposal to be able to support [Vite](https://vitejs.dev), `export = cardValidator` is not valid when targeting ES6. This PR fixes it, and as card-validator depends on other old libraries I also needed to do some other changes in order to make it work (I refer to my way of exporting `creditCardType`).

The downside of this PR is that you can't do default imports anymore (like the one you ship with your documentation, `import valid from 'card-validator'`) but you need to import the single utils. This could be made better, maybe targetting ESNext and starting a fixing chain to the dependent libraries as well.

Also, to avoid naming ambiguity between `number` function and the primitive, i suggest to remove the `number` export and use the one I added, `cardNumber`, instead, but I didn't make it as it's another super-breaking change.

Actually, I published another package that ships with this changes (`card-validator-es6`), of course if you decide to merge this I will unpublish that to avoid confusion.

If you have better solutions in mind, please share them :-)

Best regards,

Alex

