### PR TITLE
refactor: Replace local CreditCardType with import from credit-card-type library

### DIFF
--- a/src/card-number.ts
+++ b/src/card-number.ts
@@ -1,19 +1,7 @@
 import luhn10 = require("./luhn-10");
 import getCardTypes = require("credit-card-type");
 import type { Verification } from "./types";
-
-// TODO this should probably come from credit-card-type
-type CreditCardType = {
-  niceType: string;
-  type: string;
-  patterns: Array<number[] | number>;
-  gaps: number[];
-  lengths: number[];
-  code: {
-    name: string;
-    size: number;
-  };
-};
+import { CreditCardType } from "credit-card-type/dist/types";
 
 export interface CardNumberVerification extends Verification {
   card: CreditCardType | null;


### PR DESCRIPTION
This PR introduces a significant improvement to how we handle credit card type definitions within our application. Previously, we maintained a local `CreditCardType` interface, which required manual updates and maintenance. To enhance maintainability, reliability, and to leverage community-driven updates, this change shifts our approach to utilize the `CreditCardType` definition from the well-established `credit-card-type` library.

Key Changes:

- Removed the locally defined CreditCardType interface.
- Imported CreditCardType from credit-card-type/dist/types to replace our local definition.
- Adjusted relevant code to align with the structure and naming conventions of the imported CreditCardType.

This refactoring does not introduce any new features or directly alter the application's functionality from an end-user perspective. However, it lays a stronger foundation for future development and potential feature enhancements related to credit card processing.

Please review the changes for accuracy and compatibility with existing credit card processing functionalities. 