### PR TITLE
DTBTWEB-125 Make whitespace postal code invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
+# UNRELEASED
+
+- Update postal code validation to:
+  - strip trailing and leading whitespace
+  - verify postal code is at least 3 characters
+  - confirm 1st three characters are alphanumeric
+
 # 9.1.0 
+
 - Support skipping of luhn check digit validation in card number validator. 
 
 # 9.0.0
@@ -46,7 +54,7 @@ _Breaking Changes_
 
   # 6.1.0
 
-- Add option to set a `maxLength` for card number valiation
+- Add option to set a `maxLength` for card number validation
 
   # 6.0.0
 

--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ The `cvv` validation by default tests for a numeric string of 3 characters in le
 
 #### `valid.postalCode(value: string, [options: object]): object`
 
-The `postalCode` validation essentially tests for a valid string greater than 3 characters in length.
+The `postalCode` validation essentially ignores leading whitespace and tests for a valid string greater than 3 characters in length. It also verifies that the first 3 letters are alphanumeric.
 
 ```javascript
 {
@@ -354,7 +354,7 @@ The `postalCode` validation essentially tests for a valid string greater than 3 
 }
 ```
 
-You can optionally pass `minLength` as a property of an object as a second argument. This will override the default min length of 3.
+You can optionally pass `minLength` as a property of an object as a second argument. This will override the default min length of 3 and verify that the characters for the specified length are all alphanumeric.
 
 ```javascript
 valid.postalCode('123', {minLength: 5});

--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ The `cvv` validation by default tests for a numeric string of 3 characters in le
 
 #### `valid.postalCode(value: string, [options: object]): object`
 
-The `postalCode` validation essentially ignores leading whitespace and tests for a valid string greater than 3 characters in length. It also verifies that the first 3 letters are alphanumeric.
+The `postalCode` validation essentially ignores leading/trailing whitespace and tests for a valid string greater than 3 characters in length. It also verifies that the first 3 letters are alphanumeric.
 
 ```javascript
 {

--- a/src/__tests__/postal-code.ts
+++ b/src/__tests__/postal-code.ts
@@ -42,6 +42,16 @@ describe("postalCode", () => {
     ],
 
     [
+      "returns isPotentiallyValid for strings without alphanumeric first three characters",
+      [
+        ["123", { isValid: true, isPotentiallyValid: true }],
+        ["  123", { isValid: true, isPotentiallyValid: true }],
+        ["---", { isValid: false, isPotentiallyValid: true }],
+        ["   ---", { isValid: false, isPotentiallyValid: true }],
+      ],
+    ],
+
+    [
       "returns isPotentiallyValid for shorter-than-3 strings",
       [
         ["", { isValid: false, isPotentiallyValid: true }],
@@ -85,6 +95,10 @@ describe("postalCode", () => {
       });
       expect(postalCode("1234", { minLength: 4 })).toEqual({
         isValid: true,
+        isPotentiallyValid: true,
+      });
+      expect(postalCode(" -$%", { minLength: 0 })).toEqual({
+        isValid: false,
         isPotentiallyValid: true,
       });
     });

--- a/src/postal-code.ts
+++ b/src/postal-code.ts
@@ -5,6 +5,7 @@ type PostalCodeOptions = {
 };
 
 const DEFAULT_MIN_POSTAL_CODE_LENGTH = 3;
+const ALPHANUM = new RegExp(/^[a-z0-9]+$/i);
 
 function verification(
   isValid: boolean,
@@ -22,6 +23,8 @@ export function postalCode(
   if (typeof value !== "string") {
     return verification(false, false);
   } else if (value.length < minLength) {
+    return verification(false, true);
+  } else if (!ALPHANUM.test(value.trim().slice(0, minLength))) {
     return verification(false, true);
   }
 


### PR DESCRIPTION
Update postal-code validation
* to trim leading/trailing white-space
* test for 3-char min postal code length
* verify that 1st 3 characters are alphanumeric.