### PR TITLE
Fix build failure

### DIFF
--- a/src/__tests__/expiration-year.ts
+++ b/src/__tests__/expiration-year.ts
@@ -131,12 +131,20 @@ describe("expirationYear", () => {
       "accepts two-digit years",
       [
         [
-          yearsFromNow(0, 2),
-          { isValid: true, isPotentiallyValid: true, isCurrentYear: true },
+          "19",
+          { isValid: false, isPotentiallyValid: false, isCurrentYear: false },
         ],
         [
-          yearsFromNow(-5, 2),
+          "20",
+          { isValid: false, isPotentiallyValid: true, isCurrentYear: false },
+        ],
+        [
+          "21",
           { isValid: false, isPotentiallyValid: false, isCurrentYear: false },
+        ],
+        [
+          yearsFromNow(0, 2),
+          { isValid: true, isPotentiallyValid: true, isCurrentYear: true },
         ],
         [
           yearsFromNow(5, 2),


### PR DESCRIPTION
As of the new year, we started seeing a test failure that I believe was caused by the intersection of:
1. A test using a relative offset into the past
2. The need to correctly identify a valid 2-digit number as a prefix for a valid 4-digit year (e.g. `20` is a potentially valid expiration year because you could continue typing and input `2030`, which is valid)
3. The test helper function `yearsFromNow` which optionally gives you the last 2 digits of a year (e.g. given the current year is 2025, `yearsFromNow(-5, 2)` will give you `"20"` as output)

So, why did the test fail?
- On December 31st, 2024, the code `yearsFromNow(-5, 2)` returned `"19"`, which is not a potentially valid prefix; the test captured this correctly. However, on January 1st 2025, the code `yearsFromNow(-5, 2)` returned `"20"`, which _is_ a potentially valid prefix, and the test that was expecting it to not be potentially valid, now fails.

I wanted to make the fix be as unobtrusive as possible, so my preferred solution is to replace the test that was failing with 3 hard-coded tests that show the expected behavior of the year prefixes `"19"`, `"20"`, and `"21"`. This fixes the build with a small diff, and is a robust enough solution to be valid until 2081 when `"21"` becomes a valid year prefix.