### PR TITLE
Enhance cardholder name validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "card-validator",
-      "version": "10.0.1",
+      "version": "10.0.2",
       "license": "MIT",
       "dependencies": {
         "credit-card-type": "^10.0.2"

--- a/src/__tests__/cardholder-name.ts
+++ b/src/__tests__/cardholder-name.ts
@@ -1,5 +1,6 @@
 import { cardholderName } from "../cardholder-name";
 import type { Verification } from "../types";
+import { cvv } from '../cvv'
 
 describe("cardholderName", () => {
   describe.each([
@@ -23,10 +24,10 @@ describe("cardholderName", () => {
     ],
 
     [
-      "returns false strings that are longer than 255 characters",
+      "returns false strings that are longer than 24 characters",
       [
         [
-          "this name is 256 chracters aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "this name is 25 chracters",
           { isValid: false, isPotentiallyValid: false },
         ],
       ],
@@ -38,12 +39,12 @@ describe("cardholderName", () => {
         ["name", { isValid: true, isPotentiallyValid: true }],
         ["given sur", { isValid: true, isPotentiallyValid: true }],
         [
-          "this name is 255 chracters aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "this name is 24 charssss",
           { isValid: true, isPotentiallyValid: true },
         ],
         ["name with many spaces", { isValid: true, isPotentiallyValid: true }],
         [
-          "name with number in it 01234",
+          "with number in it 01234",
           { isValid: true, isPotentiallyValid: true },
         ],
       ],
@@ -70,4 +71,32 @@ describe("cardholderName", () => {
       });
     },
   );
+
+  describe("maxLength", () => {
+    it("defaults maxLength to 24", () => {
+      expect(cardholderName("this name is 25 chracters")).toEqual({
+        isValid: false,
+        isPotentiallyValid: false,
+      });
+      expect(cardholderName("this name is 24 charssss")).toEqual({ isValid: true, isPotentiallyValid: true });
+    });
+
+    it("accepts maxLength", () => {
+      expect(cardholderName("this name is 25 chracters", 25)).toEqual({
+        isValid: true,
+        isPotentiallyValid: true,
+      });
+    });
+
+    it("returns invalid if beyond maxLength", () => {
+      expect(cardholderName("this name is 25 chracters")).toEqual({
+        isValid: false,
+        isPotentiallyValid: false,
+      });
+      expect(cardholderName("this name is 26 characters", 25)).toEqual({
+        isValid: false,
+        isPotentiallyValid: false,
+      });
+    });
+  });
 });

--- a/src/cardholder-name.ts
+++ b/src/cardholder-name.ts
@@ -1,7 +1,7 @@
 import type { Verification } from "./types";
 
 const CARD_NUMBER_REGEX = /^[\d\s-]*$/;
-const MAX_LENGTH = 255;
+const DEFAULT_LENGTH = 24;
 
 function verification(
   isValid: boolean,
@@ -10,7 +10,10 @@ function verification(
   return { isValid, isPotentiallyValid };
 }
 
-export function cardholderName(value: string | unknown): Verification {
+export function cardholderName(
+  value: string | unknown,
+  maxLength: number = DEFAULT_LENGTH,
+): Verification {
   if (typeof value !== "string") {
     return verification(false, false);
   }
@@ -19,10 +22,12 @@ export function cardholderName(value: string | unknown): Verification {
     return verification(false, true);
   }
 
-  if (value.length > MAX_LENGTH) {
+  if (value.length > maxLength) {
     return verification(false, false);
   }
 
+  // If the cardholder name only contains numbers, hyphens, and spaces, it's not valid,
+  // but it may still be potentially valid if a non-numeric character is added.
   if (CARD_NUMBER_REGEX.test(value)) {
     return verification(false, true);
   }


### PR DESCRIPTION
The cardholder name is in fact should have a very limited max length.
Although it differs per issuer, it should be mostly covered by the limit of 24.
For example, Stripe own issued cards have this limit ([see more](https://docs.stripe.com/api/issuing/cardholders/create)).
This is important, because some acquirers will trigger a fraud detection if the cardholder name doesn't match exactly as on the card (incl. abbreviation due to this max length).

------

- [x] Default max length to 24
- [x] Accept custom max length 