### PR TITLE
Add publishing gh actions, update existing action

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+### Summary
+
+<!-- Summarize the change and indicate whether this will be a major/minor/patch change -->
+
+### Checklist
+
+- [ ] Added a changelog entry
+
+### Authors
+
+> List GitHub usernames for everyone who contributed to this pull request.
+
+-
+
+### Reviewers
+
+@braintree/team-sdk-js 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,14 @@
 name: "Unit Tests"
 
-on: [push]
+on:
+  push:
+    branches:
+      - 'main'
+  workflow_dispatch:
+  workflow_call:
+  pull_request:
+    branches:
+        - '*'
 
 jobs:
   build:
@@ -10,8 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
-          node-version: "18.x"
+          node-version-file: .nvmrc
       - run: npm install
       - run: npm test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,47 @@
+# This workflow will run tests using node, bump the npm version, deploy to npm, and create a release with notes 
+
+name: Publish to npm 
+run-name: Deploy ${{ github.repository }} to npmjs by @${{ github.actor }}
+on:
+    workflow_dispatch:
+      inputs:
+        version_type:
+          description: "Version bump type (major, minor, patch)"
+          required: true
+          type: choice
+          options:
+            - major
+            - minor
+            - patch
+
+env:
+    NPM_REGISTRY: https://registry.npmjs.org/
+
+concurrency: # prevent concurrent releases
+  group: npm-publish 
+  cancel-in-progress: true
+
+jobs:
+  ci: 
+    uses: ./.github/workflows/ci.yml
+  bump-version:
+    needs: ci
+    uses: ./.github/workflows/version-bump.yml
+    with:
+      version_type: ${{ inputs.version_type }}
+  publish-npm:
+    needs: bump-version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          registry-url: ${{ env.NPM_REGISTRY }} 
+      - run: npm ci
+      - run: npm publish --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.BRAINTREE_NPM_ACCESS_TOKEN }}
+  publish-release:
+    needs: publish-npm
+    uses: ./.github/workflows/release-notes.yml 

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,0 +1,39 @@
+# This workflow will create a release for the most recent deploy 
+
+name: Create release 
+run-name: Running github release 
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  create_release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - name: Get version
+        run: echo "latest_version=$(npm pkg get version --workspaces=false | tr -d \")" >> $GITHUB_ENV
+
+      - name: Get details
+        run: |
+          {
+            echo 'release_details<<EOF'
+            awk '/^## / { if (p) exit; p=1 } p' CHANGELOG.md | sed '1d'
+            echo EOF
+          } >> $GITHUB_ENV
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          tag_name: ${{ env.latest_version }}
+          release_name: v${{ env.latest_version }}
+          body: "${{ env.release_details }}"
+          draft: false
+          prerelease: false 

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,65 @@
+# This workflow will bump the version
+
+name: Bump version and update changelog
+
+on:
+  workflow_call:
+    inputs:
+      version_type:
+        description: "Version bump type (major, minor, patch)"
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      version_type:
+        description: "Version bump type (major, minor, patch)"
+        required: true
+        type: choice
+        options:
+          - major
+          - minor
+          - patch
+
+jobs:
+  version_bump:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+
+      - name: Configure Github Credentials
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Check Changelog
+        run: |
+          if ! grep -i -q "## UNRELEASED" CHANGELOG.md; then
+            echo "Error: 'UNRELEASED' not found in CHANGELOG.md. Please ensure the changelog is correctly formatted."
+            exit 1
+          fi
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - name: Bump npm version
+        run: |
+          new_version=$(npm version ${{ inputs.version_type }})
+          echo "new_version=$(echo $new_version | sed 's/v//')" >> $GITHUB_ENV
+        
+      - name: Update changelog
+        run: |
+           today=$(date +'%Y-%m-%d')
+           sed -i "s/## unreleased/## ${{ env.new_version }} (${today})/i" CHANGELOG.md
+
+      - name: Commit and push changes
+        run: |
+          git tag -m  ${{ env.new_version }} ${{ env.new_version }}
+          git add --all
+          git commit -m "v${{ env.new_version }}"
+          git push


### PR DESCRIPTION
### Summary

<!-- Summarize the change and indicate whether this will be a major/minor/patch change -->
Adding/updating a series of Github Actions workflows to automate publishing to NPM. 

#### New:
- **version-bump.yml**
  - Automatically bumps npm version
  - Runs manually or via `publish.yml`
- **release-notes.yml**
  - Automatically creates a Github Release with notes
  - Runs manually or via `publish.yml`
- **publish.yml**
  - Does both of the above, runs `ci-unit-tests.yml` AND publishes package to npm
  - Runs manually but can be configured to run on merge to main
- **PULL_REQUEST_TEMPLATE.md**
  - A standardized template for PRs

#### Updated:
- **ci.yml**
  - Bumped `actions/setup-node` to v4
  - Updated to be more dynamic (read nvmrc for node version)


### Checklist

- ~Added a changelog entry~ *Changelog unnecessary—no functionality changes*

### Authors

> List GitHub usernames for everyone who contributed to this pull request.

- @CJGlitter 

### Reviewers

@braintree/team-sdk-js 