### PR TITLE
Update UK postal codes validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # 10.0.3
 
 - Updating postal code input to consider strings of length 2 to be valid input to support UK postal code format `XX XXX`.
-- Updated unit tests
 
 # 10.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 10.0.3
+# UNRELEASED
 
 - Updating postal code input to consider strings of length 2 to be valid input to support UK postal code format `XX XXX`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 10.0.3
+
+- Updating postal code input to consider strings of length 2 to be valid input to support UK postal code format `XX XXX`.
+- Updated unit tests
+
 # 10.0.2
 
 - Update `credit-card-type` to 10.0.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "card-validator",
-      "version": "10.0.1",
+      "version": "10.0.2",
       "license": "MIT",
       "dependencies": {
         "credit-card-type": "^10.0.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "card-validator",
-  "version": "10.0.2",
+  "version": "10.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "card-validator",
-  "version": "10.0.1",
+  "version": "10.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "card-validator",
-  "version": "10.0.3",
+  "version": "10.0.2",
   "description": "A library for validating credit card fields",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "card-validator",
-  "version": "10.0.2",
+  "version": "10.0.3",
   "description": "A library for validating credit card fields",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/__tests__/postal-code.ts
+++ b/src/__tests__/postal-code.ts
@@ -32,6 +32,8 @@ describe("postalCode", () => {
         ["557016", { isValid: true, isPotentiallyValid: true }], // Romania
         ["110001", { isValid: true, isPotentiallyValid: true }], // India
         ["SE1 2LN", { isValid: true, isPotentiallyValid: true }], // UK
+        ["S9 1DF", { isValid: true, isPotentiallyValid: true }], // UK
+        ["AA9A 9AA", { isValid: true, isPotentiallyValid: true }], // UK
         ["01234567890123456789", { isValid: true, isPotentiallyValid: true }], // some hypothetical country
       ],
     ],
@@ -52,11 +54,11 @@ describe("postalCode", () => {
     ],
 
     [
-      "returns isPotentiallyValid for shorter-than-3 strings",
+      "returns isPotentiallyValid for shorter-than-2 strings",
       [
         ["", { isValid: false, isPotentiallyValid: true }],
         ["1", { isValid: false, isPotentiallyValid: true }],
-        ["12", { isValid: false, isPotentiallyValid: true }],
+        ["12", { isValid: true, isPotentiallyValid: true }],
       ],
     ],
   ] as Array<[string, Array<[string, Verification]>]>)(
@@ -79,10 +81,18 @@ describe("postalCode", () => {
         isPotentiallyValid: true,
       });
       expect(postalCode("12")).toEqual({
-        isValid: false,
+        isValid: true,
         isPotentiallyValid: true,
       });
       expect(postalCode("12", {})).toEqual({
+        isValid: true,
+        isPotentiallyValid: true,
+      });
+      expect(postalCode("1")).toEqual({
+        isValid: false,
+        isPotentiallyValid: true,
+      });
+      expect(postalCode("1", {})).toEqual({
         isValid: false,
         isPotentiallyValid: true,
       });

--- a/src/postal-code.ts
+++ b/src/postal-code.ts
@@ -11,6 +11,7 @@ function verification(
   isValid: boolean,
   isPotentiallyValid: boolean,
 ): Verification {
+  console.log("testing");
   return { isValid, isPotentiallyValid };
 }
 

--- a/src/postal-code.ts
+++ b/src/postal-code.ts
@@ -11,7 +11,6 @@ function verification(
   isValid: boolean,
   isPotentiallyValid: boolean,
 ): Verification {
-  console.log("testing");
   return { isValid, isPotentiallyValid };
 }
 

--- a/src/postal-code.ts
+++ b/src/postal-code.ts
@@ -4,7 +4,7 @@ type PostalCodeOptions = {
   minLength?: number;
 };
 
-const DEFAULT_MIN_POSTAL_CODE_LENGTH = 3;
+const DEFAULT_MIN_POSTAL_CODE_LENGTH = 2;
 const ALPHANUM = new RegExp(/^[a-z0-9]+$/i);
 
 function verification(


### PR DESCRIPTION
### Summary

<!-- Summarize the change and indicate whether this will be a major/minor/patch change -->
Updating postal code input to consider strings of length 2 to be valid input to support UK postal code format `XX XXX`.

#### Updated:
- Updating postal code input to consider strings of length 2 to be valid input to support UK postal code format `XX XXX`.

### Checklist

- Added a changelog entry

### Authors

> List GitHub usernames for everyone who contributed to this pull request.

- @codentacos 

### Reviewers

@braintree/team-sdk-js 